### PR TITLE
change archetype schema accessor and mutator

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,14 @@ Change History
 1.3 (unreleased)
 ================
 
+- Fix field accessor and mutator for updating schemaextended field values
+  with schemaupdater.
+  In some cases when using fields extended by schemaextender it defines
+  an accessor attribute which is not accessable. To cover all fields, its better
+  to access and mutate over the getAccessor and getMutator methods on archetype
+  fields.
+  [elioschmutz]
+
 - Add a section to manage `plone.app.redirector`_ and to use it to
   update paths.
   [rpatterson]

--- a/src/plone/app/transmogrifier/atschemaupdater.py
+++ b/src/plone/app/transmogrifier/atschemaupdater.py
@@ -25,16 +25,11 @@ def _compare(fieldval, itemval):
 
 
 def get(field, obj):
-    if field.accessor is not None:
-        return getattr(obj, field.accessor)()
-    return field.get(obj)
+    return field.getAccessor(obj)()
 
 
 def set(field, obj, val):
-    if field.mutator is not None:
-        getattr(obj, field.mutator)(val)
-    else:
-        field.set(obj, val)
+    field.getMutator(obj)(val)
 
 
 class ATSchemaUpdaterSection(object):


### PR DESCRIPTION
@rpatterson hey, i've changed the getter and setter methods for schemaupdater.
Coul'd you take a look on it and merge my branch into the master if it's ok?

Fix field accessor and mutator for updating schemaextended field values with schemaupdater. In some cases when using fields extended by schemaextender it defines an accessor attribute which is not accessable. To cover all fields, its better to access and mutate over the getAccessor and getMutator methods on archetype fields.
