### PR TITLE
import transition dates in workflow history

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,8 @@ Change History
 1.3 (unreleased)
 ================
 
+- Allow to import transition date in the worflow history
+  [ebrehault]
 - Fix field accessor and mutator for updating schemaextended field values
   with schemaupdater.
   In some cases when using fields extended by schemaextender it defines

--- a/src/plone/app/transmogrifier/tests.py
+++ b/src/plone/app/transmogrifier/tests.py
@@ -1,5 +1,6 @@
 import posixpath
 import unittest
+from DateTime.DateTime import DateTime
 from zope.component import provideUtility
 from zope.interface import classProvides, implements
 from zope.testing import doctest
@@ -160,6 +161,8 @@ def workflowUpdaterSetUp(test):
 
         updated = []
 
+        workflow_history = {}
+
         def doActionFor(self, ob, action):
             assert isinstance(ob, self.__class__)
             if action == 'nonsuch':
@@ -185,6 +188,10 @@ def workflowUpdaterSetUp(test):
                 dict(_path='/spam/eggs/nosuchtransition',
                      _transitions=('nonsuch',),
                      title='Should not be updated, no such transition'),
+                dict(_path='/spam/eggs/bla', _transitions=(
+                        {'action': 'spam', 'review_state': 'spammed', 'time': DateTime("2014-06-20")},
+                    )
+                ),
             )
     provideUtility(WorkflowSource,
         name=u'plone.app.transmogrifier.tests.workflowsource')

--- a/src/plone/app/transmogrifier/workflowupdater.py
+++ b/src/plone/app/transmogrifier/workflowupdater.py
@@ -41,9 +41,26 @@ class WorkflowUpdaterSection(object):
                 yield item; continue
             
             for transition in transitions:
-                try:
-                    self.wftool.doActionFor(obj, transition)
-                except WorkflowException:
-                    pass
+                if not isinstance(transition, basestring):
+                    state = transition['review_state']
+                    time = transition['time']
+                    action = transition.get('action')
+                    # no action if initial state
+                    if action:
+                        try:
+                            self.wftool.doActionFor(obj, action)
+                        except WorkflowException:
+                            pass
+                    history = obj.workflow_history
+                    for wf in history:
+                        for wf_state in history[wf]:
+                            if wf_state['review_state'] == state:
+                                wf_state['time'] = time
+                    obj.workflow_history = history
+                else:
+                    try:
+                        self.wftool.doActionFor(obj, transition)
+                    except WorkflowException:
+                        pass
             
             yield item

--- a/src/plone/app/transmogrifier/workflowupdater.txt
+++ b/src/plone/app/transmogrifier/workflowupdater.txt
@@ -32,7 +32,10 @@ as ``path-key``), defaulting to
 
 Unicode paths are encoded to ASCII. Paths to objects are always interpreted as
 relative to the context object. Transitions are specified as a sequence of
-transition names, or as a string specifying one transition. Transitions are
+transition names, or as a string specifying one transition, or a list of 
+dictionaries containing 'action' as transition id, 'review_state' as state id 
+and 'time' as a DateTime representing the transition time (if so, the worflow
+history will be updated with the provided date). Transitions are
 executed in order, failing transitions are silently ignored.
 
     >>> import pprint
@@ -72,7 +75,14 @@ executed in order, failing transitions are silently ignored.
         {'_path': '/spam/eggs/nosuchtransition',
        '_transitions': ('nonsuch',),
        'title': 'Should not be updated, no such transition'}
+    logger INFO
+        {'_path': '/spam/eggs/bla',
+       '_transitions': ({'action': 'spam',
+                         'review_state': 'spammed',
+                         'time': DateTime('2014/06/20 00:00:00 GMT+0')},)}
+
     >>> pprint.pprint(plone.updated)
     [('spam/eggs/foo', 'spam'),
      ('spam/eggs/baz', 'spam'),
-     ('spam/eggs/baz', 'eggs')]
+     ('spam/eggs/baz', 'eggs'),
+     ('spam/eggs/bla', 'spam')]


### PR DESCRIPTION
in addition to string or list of string (designating the transitions to perform), we can now also provide dictionaries like:

```
_transitions=(
    {'action': 'spam', 'review_state': 'spammed', 'time': DateTime("2014-06-20")},
)
```

and the workflow history is updated accordingly.
